### PR TITLE
Pin actions/deploy-pages and actions/upload-pages-artifact to SHA

### DIFF
--- a/.github/workflows/gcp-iam-catalog-generate.yaml
+++ b/.github/workflows/gcp-iam-catalog-generate.yaml
@@ -44,7 +44,7 @@ jobs:
           ./gcp-iam-catalog -generate
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./html  # Match the directory where the static files are generated
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
Pin `actions/deploy-pages@v5` and `actions/upload-pages-artifact@v5` to verified commit SHAs.

- `actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0`
- `actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0`

These SHAs match the versions already pinned in other repos in the org.