### PR TITLE
feat: add deprecated role indicators and case-insensitive comparison

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ type Role struct {
 	Stage               string   `json:"stage"`
 	PermissionCount     int      `json:"-"` // Not stored in JSON
 	LastCrawled         string   `json:"-"` // Not stored in JSON
+	Deprecated          bool     `json:"-"` // Computed during generation only
 }
 
 // PermissionIndex maps permissions to roles
@@ -77,6 +78,11 @@ func classifyRoleType(roleName string) string {
 
 	// All others are predefined roles
 	return "Predefined"
+}
+
+func isDeprecatedRole(role Role) bool {
+	return strings.EqualFold(role.Stage, "DEPRECATED") ||
+		strings.Contains(strings.ToLower(role.Description), "deprecated")
 }
 
 func main() {
@@ -262,6 +268,12 @@ func generateHTML() error {
 		"classifyRole": func(roleName string) string {
 			return classifyRoleType(roleName)
 		},
+		"displayRoleName": func(roleName string, deprecated bool) string {
+			if deprecated {
+				return roleName + " ⛔"
+			}
+			return roleName
+		},
 	})
 
 	// Then parse all templates
@@ -291,6 +303,7 @@ func generateHTML() error {
 
 		// Sort IncludedPermissions alphabetically
 		sort.Strings(role.IncludedPermissions)
+		role.Deprecated = isDeprecatedRole(role)
 
 		roles = append(roles, role)
 
@@ -373,6 +386,23 @@ func generateHTML() error {
 	for perm := range permissionIndex {
 		permissionNames = append(permissionNames, perm)
 	}
+
+	type RoleMetadata struct {
+		Deprecated bool `json:"deprecated"`
+	}
+	roleMetadata := make(map[string]RoleMetadata, len(roles))
+	for _, role := range roles {
+		roleMetadata[role.Name] = RoleMetadata{Deprecated: role.Deprecated}
+	}
+	roleMetadataPath := filepath.Join(htmlDir, "roles-metadata.json")
+	roleMetadataJSON, err := json.Marshal(roleMetadata)
+	if err != nil {
+		log.Printf("Failed to marshal roles metadata: %v", err)
+	} else if err := os.WriteFile(roleMetadataPath, roleMetadataJSON, 0644); err != nil {
+		log.Printf("Failed to write roles metadata: %v", err)
+	} else {
+		log.Printf("Generated roles metadata at %s", roleMetadataPath)
+	}
 	sort.Strings(permissionNames)
 	permissionsListPath := filepath.Join(htmlDir, "permissions-list.json")
 	permissionsListJSON, err := json.Marshal(permissionNames)
@@ -427,18 +457,21 @@ func generateHTML() error {
 
 		// Populate Roles with Name and Title
 		var detailedRoles []struct {
-			Name  string
-			Title string
+			Name       string
+			Title      string
+			Deprecated bool
 		}
 		for _, roleName := range rolesWithPerm {
 			for _, role := range roles {
 				if role.Name == roleName {
 					detailedRoles = append(detailedRoles, struct {
-						Name  string
-						Title string
+						Name       string
+						Title      string
+						Deprecated bool
 					}{
-						Name:  role.Name,
-						Title: role.Title,
+						Name:       role.Name,
+						Title:      role.Title,
+						Deprecated: role.Deprecated,
 					})
 					break
 				}
@@ -455,8 +488,9 @@ func generateHTML() error {
 			RoleCount  int
 			Permission string
 			Roles      []struct {
-				Name  string
-				Title string
+				Name       string
+				Title      string
+				Deprecated bool
 			}
 			LastCrawled string
 			PathPrefix  string

--- a/templates/permission.html
+++ b/templates/permission.html
@@ -63,7 +63,7 @@
                                     <span class="role-indicator"></span>
                                     <a href="{{$.PathPrefix}}{{.Name}}.html" class="role-name">
                                         {{.Name}}
-                                    </a>
+                                    </a>{{if .Deprecated}} ⛔{{end}}
                                 </div>
                                 <div class="role-type-cell">
                                     {{classifyRole .Name}}
@@ -137,6 +137,7 @@
         const MAX_BAR_WIDTH = 200;
         const pathPrefix = '{{.PathPrefix}}';
         let allPermissions = [];
+        let roleMetadata = {};
         let selectedPermission = '';
 
         // Load permissions list on page load
@@ -151,6 +152,27 @@
             } catch (err) {
                 console.error('Error loading permissions list:', err);
             }
+        }
+
+        async function loadRoleMetadata() {
+            try {
+                const response = await fetch(pathPrefix + 'roles-metadata.json');
+                if (response.ok) {
+                    roleMetadata = await response.json();
+                } else {
+                    console.error('Failed to load roles metadata: HTTP', response.status);
+                }
+            } catch (err) {
+                console.error('Error loading roles metadata:', err);
+            }
+        }
+
+        function displayRoleName(role) {
+            return role + (roleMetadata[role] && roleMetadata[role].deprecated ? ' ⛔' : '');
+        }
+
+        function normalizeCompareValue(value) {
+            return value.toLowerCase();
         }
 
         function copyPermission() {
@@ -265,12 +287,13 @@
                 compareInput.classList.remove('input-error');
                 
                 const otherData = await response.json();
-                const otherRoles = new Set(otherData.roles || []);
-                const currentRolesSet = new Set(currentRoles);
+                const otherRoles = otherData.roles || [];
+                const otherRoleKeys = new Set(otherRoles.map(normalizeCompareValue));
+                const currentRoleKeys = new Set(currentRoles.map(normalizeCompareValue));
 
-                const onlyLeft = currentRoles.filter(r => !otherRoles.has(r)).sort();
-                const onlyRight = Array.from(otherRoles).filter(r => !currentRolesSet.has(r)).sort();
-                const common = currentRoles.filter(r => otherRoles.has(r)).sort();
+                const onlyLeft = currentRoles.filter(r => !otherRoleKeys.has(normalizeCompareValue(r))).sort();
+                const onlyRight = otherRoles.filter(r => !currentRoleKeys.has(normalizeCompareValue(r))).sort();
+                const common = currentRoles.filter(r => otherRoleKeys.has(normalizeCompareValue(r))).sort();
 
                 // Update URL with compare parameter
                 const url = new URL(window.location);
@@ -338,13 +361,14 @@
                 a.href = baseUrl + roleShortName.split('/').map(encodeURIComponent).join('/') + '.html';
                 a.textContent = item;
                 div.appendChild(a);
+
                 container.appendChild(div);
             });
         }
 
         // Handle URL parameters on page load
         document.addEventListener('DOMContentLoaded', async function() {
-            await loadPermissionsList();
+            await Promise.all([loadPermissionsList(), loadRoleMetadata()]);
             
             const params = new URLSearchParams(window.location.search);
             const compareWith = params.get('compare');

--- a/templates/role.html
+++ b/templates/role.html
@@ -25,7 +25,7 @@
                 <span class="detail-icon">🔐</span>
                 <div class="detail-title">
                     <h1>
-                        <span id="role-id">{{.Name}}</span>
+                        <span id="role-id">{{.Name}}</span>{{if .Deprecated}} ⛔{{end}}
                         <button class="copy-button" onclick="copyRole()" aria-label="Copy Role">📋 Copy</button>
                     </h1>
                 </div>
@@ -121,7 +121,7 @@
                     <div class="compare-results" id="compareResults" style="display: none;">
                         <div class="compare-column left">
                             <div class="compare-column-header">
-                                <span class="compare-header-title">{{.Name}}</span>
+                                <span class="compare-header-title">{{displayRoleName .Name .Deprecated}}</span>
                                 <span class="compare-count" id="leftCount">0</span>
                             </div>
                             <div class="compare-column-content" id="leftList"></div>
@@ -153,6 +153,7 @@
         const currentPermissions = [{{range $i, $p := .IncludedPermissions}}{{if $i}},{{end}}"{{$p}}"{{end}}];
         const MAX_BAR_WIDTH = 200;
         let allRoles = [];
+        let roleMetadata = {};
         let selectedRole = '';
 
         // Load roles list on page load
@@ -167,6 +168,27 @@
             } catch (err) {
                 console.error('Error loading roles list:', err);
             }
+        }
+
+        async function loadRoleMetadata() {
+            try {
+                const response = await fetch('../roles-metadata.json');
+                if (response.ok) {
+                    roleMetadata = await response.json();
+                } else {
+                    console.error('Failed to load roles metadata: HTTP', response.status);
+                }
+            } catch (err) {
+                console.error('Error loading roles metadata:', err);
+            }
+        }
+
+        function displayRoleName(role) {
+            return role + (roleMetadata[role] && roleMetadata[role].deprecated ? ' ⛔' : '');
+        }
+
+        function normalizeCompareValue(value) {
+            return value.toLowerCase();
         }
 
         function copyRole() {
@@ -283,12 +305,13 @@
                 compareInput.classList.remove('input-error');
                 
                 const otherData = await response.json();
-                const otherPerms = new Set(otherData.included_permissions || []);
-                const currentPerms = new Set(currentPermissions);
+                const otherPerms = otherData.included_permissions || [];
+                const otherPermKeys = new Set(otherPerms.map(normalizeCompareValue));
+                const currentPermKeys = new Set(currentPermissions.map(normalizeCompareValue));
 
-                const onlyLeft = currentPermissions.filter(p => !otherPerms.has(p)).sort();
-                const onlyRight = Array.from(otherPerms).filter(p => !currentPerms.has(p)).sort();
-                const common = currentPermissions.filter(p => otherPerms.has(p)).sort();
+                const onlyLeft = currentPermissions.filter(p => !otherPermKeys.has(normalizeCompareValue(p))).sort();
+                const onlyRight = otherPerms.filter(p => !currentPermKeys.has(normalizeCompareValue(p))).sort();
+                const common = currentPermissions.filter(p => otherPermKeys.has(normalizeCompareValue(p))).sort();
 
                 // Update URL with compare parameter
                 const url = new URL(window.location);
@@ -296,7 +319,7 @@
                 window.history.replaceState({}, '', url);
 
                 // Update header
-                document.getElementById('rightHeader').textContent = otherRole;
+                document.getElementById('rightHeader').textContent = displayRoleName(otherRole);
 
                 // Populate lists
                 populateCompareList('leftList', onlyLeft, '../permissions/', 'permission');
@@ -360,7 +383,7 @@
 
         // Handle URL parameters on page load
         document.addEventListener('DOMContentLoaded', async function() {
-            await loadRolesList();
+            await Promise.all([loadRolesList(), loadRoleMetadata()]);
             
             const params = new URLSearchParams(window.location.search);
             const compareWith = params.get('compare');

--- a/templates/roles.html
+++ b/templates/roles.html
@@ -56,7 +56,7 @@
                             <span class="role-indicator"></span>
                             <a href="{{.Name}}.html" class="role-name">
                                 {{.Name}}
-                            </a>
+                            </a>{{if .Deprecated}} ⛔{{end}}
                         </div>
                         <div class="role-type-cell">
                             {{classifyRole .Name}}


### PR DESCRIPTION
## Changes

- **Deprecated role detection**: Automatically detects deprecated roles by checking the `Stage` field and searching for \deprecated\ in the role description
- **Visual indicators**: Displays a ⛔ emoji next to deprecated role names on the roles page, permission pages, and individual role pages
- **Roles metadata**: Generates `roles-metadata.json` for client-side deprecated role lookups, avoiding the need to pass this data through server-side template rendering
- **Case-insensitive comparison**: Comparison logic now normalizes role and permission names to lowercase for more accurate diffing
- **File fixes**: Added missing newlines at end of template HTML files