### PR TITLE
feat: add interactive role search page with permission-based filtering

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -31,6 +31,9 @@ a:hover {
     --permission-primary: #f59e0b;
     --permission-light: #fef3c7;
     --permission-dark: #b45309;
+    --search-primary: #6366f1;
+    --search-light: #e0e7ff;
+    --search-dark: #4338ca;
     --common-primary: #10b981;
     --common-light: #d1fae5;
     --common-dark: #047857;
@@ -289,6 +292,10 @@ ul.item-list li a:hover {
     border-left-color: var(--permission-primary);
 }
 
+.nav-card.search-card {
+    border-left-color: var(--search-primary);
+}
+
 .nav-card-icon {
     font-size: 2em;
     margin-bottom: 10px;
@@ -373,6 +380,10 @@ ul.item-list li a:hover {
 
 .permissions-page .page-header-icon {
     color: var(--permission-primary);
+}
+
+.role-search-page .page-header-icon {
+    color: var(--search-primary);
 }
 
 .role-name,
@@ -681,6 +692,170 @@ ul.item-list li a:hover {
     transform: translateY(-50%);
 }
 
+/* ============================================
+   ROLE SEARCH PAGE STYLES
+   ============================================ */
+
+.permission-filter-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.permission-filter-panel {
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    background: #fff;
+    overflow: visible;
+}
+
+.permission-filter-panel.include-panel {
+    border-top: 4px solid var(--common-primary);
+}
+
+.permission-filter-panel.exclude-panel {
+    border-top: 4px solid var(--permission-primary);
+}
+
+.filter-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 15px;
+    border-bottom: 1px solid #e5e7eb;
+    background: #f8f9fa;
+}
+
+.filter-panel-header h2 {
+    margin: 0;
+}
+
+.filter-count {
+    min-width: 28px;
+    text-align: center;
+    padding: 2px 8px;
+    border-radius: 12px;
+    background: #e5e7eb;
+    color: #374151;
+    font-size: 0.85em;
+    font-weight: 600;
+}
+
+.permission-filter-panel .compare-selector {
+    margin: 0;
+    padding: 15px;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.permission-filter-panel .compare-input-wrapper {
+    display: flex;
+    gap: 8px;
+    max-width: none;
+}
+
+.permission-filter-panel .search-input {
+    min-width: 0;
+    padding-right: 12px;
+}
+
+.add-permission-button,
+.remove-permission-button {
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: 500;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+.add-permission-button {
+    flex: 0 0 auto;
+    padding: 0 14px;
+    background: var(--search-primary);
+    color: #fff;
+}
+
+.add-permission-button:hover {
+    background: var(--search-dark);
+}
+
+.selected-permissions-list {
+    min-height: 80px;
+}
+
+.selected-permission {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 10px 15px;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.selected-permission:last-child {
+    border-bottom: none;
+}
+
+.selected-permission label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.selected-permission input {
+    flex: 0 0 auto;
+}
+
+.selected-permission a {
+    word-break: break-word;
+    overflow-wrap: break-word;
+    font-weight: 500;
+}
+
+.selected-permission.inactive a {
+    color: #9ca3af;
+    text-decoration: line-through;
+}
+
+.remove-permission-button {
+    flex: 0 0 auto;
+    padding: 5px 9px;
+    background: #f3f4f6;
+    color: #6b7280;
+    font-size: 0.85em;
+}
+
+.remove-permission-button:hover {
+    background: #e5e7eb;
+    color: #374151;
+}
+
+.selected-permission-empty,
+.search-empty-state {
+    padding: 20px;
+    color: #9ca3af;
+    font-style: italic;
+    text-align: center;
+}
+
+.match-summary {
+    margin-top: 20px;
+    padding: 12px 15px;
+    background: var(--search-light);
+    color: var(--search-dark);
+    border-radius: 6px;
+    font-weight: 600;
+}
+
+.match-summary span {
+    font-size: 1.1em;
+}
+
+.role-search-page .role-table {
+    margin-top: 15px;
+}
+
 /* Suggestions dropdown */
 .suggestions-dropdown {
     display: none;
@@ -955,5 +1130,21 @@ footer a:hover {
     .compare-input-wrapper {
         flex-direction: column;
         align-items: stretch;
+    }
+
+    .permission-filter-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .permission-filter-panel .compare-input-wrapper {
+        flex-direction: column;
+    }
+
+    .add-permission-button {
+        padding: 10px 14px;
+    }
+
+    .selected-permission {
+        align-items: flex-start;
     }
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -328,8 +328,21 @@ ul.item-list li a:hover {
 
 .feature-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
     gap: 25px;
+    justify-items: center;
+}
+
+@media (max-width: 1100px) {
+    .feature-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 700px) {
+    .feature-grid {
+        grid-template-columns: 1fr;
+    }
 }
 
 .feature-item {

--- a/main.go
+++ b/main.go
@@ -388,11 +388,17 @@ func generateHTML() error {
 	}
 
 	type RoleMetadata struct {
-		Deprecated bool `json:"deprecated"`
+		Deprecated bool   `json:"deprecated"`
+		Title      string `json:"title"`
+		Type       string `json:"type"`
 	}
 	roleMetadata := make(map[string]RoleMetadata, len(roles))
 	for _, role := range roles {
-		roleMetadata[role.Name] = RoleMetadata{Deprecated: role.Deprecated}
+		roleMetadata[role.Name] = RoleMetadata{
+			Deprecated: role.Deprecated,
+			Title:      role.Title,
+			Type:       classifyRoleType(role.Name),
+		}
 	}
 	roleMetadataPath := filepath.Join(htmlDir, "roles-metadata.json")
 	roleMetadataJSON, err := json.Marshal(roleMetadata)
@@ -575,6 +581,24 @@ func generateHTML() error {
 		return fmt.Errorf("failed to execute permissions index template: %v", err)
 	}
 	log.Printf("Generated Permissions Index at %s", permissionsIndexPath)
+
+	// Generate Search Page
+	searchPath := filepath.Join(htmlDir, "search.html")
+	fSearch, err := os.Create(searchPath)
+	if err != nil {
+		return fmt.Errorf("failed to create search HTML file: %v", err)
+	}
+	defer fSearch.Close()
+
+	err = tmpl.ExecuteTemplate(fSearch, "search.html", struct {
+		LastCrawled string
+	}{
+		LastCrawled: lastCrawled,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to execute search template: %v", err)
+	}
+	log.Printf("Generated Search page at %s", searchPath)
 
 	// Generate Home Index Page
 	homeIndexPath := filepath.Join(htmlDir, "index.html")

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,6 +13,7 @@
         <a href="index.html" class="active">gcp-iam-catalog</a>
         <a href="roles.html">Roles</a>
         <a href="permissions.html">Permissions</a>
+        <a href="search.html">Search</a>
     </div>
 
     <main>
@@ -46,6 +47,11 @@
                 <h3>Browse Permissions</h3>
                 <p>Find which roles grant a specific permission. Understand the relationship between permissions and roles.</p>
             </a>
+            <a href="search.html" class="nav-card search-card">
+                <div class="nav-card-icon">🧭</div>
+                <h3>Find Matching Roles</h3>
+                <p>Build include and exclude permission filters to identify IAM roles that fit the access profile you need.</p>
+            </a>
         </div>
 
         <!-- Features Section -->
@@ -71,6 +77,13 @@
                     <div>
                         <h4>Side-by-Side Comparison</h4>
                         <p>Compare any two roles or permissions to see what they share and what's unique to each.</p>
+                    </div>
+                </div>
+                <div class="feature-item">
+                    <div class="feature-icon">🎯</div>
+                    <div>
+                        <h4>Least-Privilege Role Discovery</h4>
+                        <p>Narrow candidates by requiring specific permissions and filtering out roles that grant access outside your target scope.</p>
                     </div>
                 </div>
                 <div class="feature-item">

--- a/templates/permission.html
+++ b/templates/permission.html
@@ -13,6 +13,7 @@
         <a href="{{.PathPrefix}}index.html">gcp-iam-catalog</a>
         <a href="{{.PathPrefix}}roles.html">Roles</a>
         <a href="{{.PathPrefix}}permissions.html" class="active">Permissions</a>
+        <a href="{{.PathPrefix}}search.html">Search</a>
     </div>
 
     <main>

--- a/templates/permissions.html
+++ b/templates/permissions.html
@@ -31,6 +31,7 @@
         <a href="index.html">gcp-iam-catalog</a>
         <a href="roles.html">Roles</a>
         <a href="permissions.html" class="active">Permissions</a>
+        <a href="search.html">Search</a>
     </div>
 
     <main>

--- a/templates/role.html
+++ b/templates/role.html
@@ -13,6 +13,7 @@
         <a href="../index.html">gcp-iam-catalog</a>
         <a href="../roles.html" class="active">Roles</a>
         <a href="../permissions.html">Permissions</a>
+        <a href="../search.html">Search</a>
     </div>
 
     <main>

--- a/templates/roles.html
+++ b/templates/roles.html
@@ -32,6 +32,7 @@
         <a href="index.html">gcp-iam-catalog</a>
         <a href="roles.html" class="active">Roles</a>
         <a href="permissions.html">Permissions</a>
+        <a href="search.html">Search</a>
     </div>
 
     <main>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,0 +1,401 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Find GCP IAM Roles - gcp-iam-catalog</title>
+    <link rel="stylesheet" href="./style.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Find GCP IAM roles by permissions they must include and permissions they must exclude.">
+</head>
+<body>
+    <!-- Navigation Bar -->
+    <div class="navbar">
+        <a href="index.html">gcp-iam-catalog</a>
+        <a href="roles.html">Roles</a>
+        <a href="permissions.html">Permissions</a>
+        <a href="search.html" class="active">Search</a>
+    </div>
+
+    <main>
+        <section class="role-search-page">
+            <div class="page-header">
+                <span class="page-header-icon">🧭</span>
+                <h1>Find Matching Roles</h1>
+            </div>
+            <p class="muted-text">Choose permissions a role must include and permissions it must not include. Matches update entirely in your browser.</p>
+
+            <div class="permission-filter-grid">
+                <div class="permission-filter-panel include-panel">
+                    <div class="filter-panel-header">
+                        <h2>Must Include</h2>
+                        <span class="filter-count" id="includeCount">0</span>
+                    </div>
+                    <div class="compare-selector">
+                        <label for="includePermission">Add required permission:</label>
+                        <div class="compare-input-wrapper">
+                            <input type="text" id="includePermission" class="search-input" placeholder="Type to search permissions..." autocomplete="off">
+                            <button type="button" class="add-permission-button" id="addIncludeButton">Add</button>
+                        </div>
+                        <div id="includeSuggestions" class="suggestions-dropdown"></div>
+                    </div>
+                    <div id="includeList" class="selected-permissions-list"></div>
+                </div>
+
+                <div class="permission-filter-panel exclude-panel">
+                    <div class="filter-panel-header">
+                        <h2>Must Exclude</h2>
+                        <span class="filter-count" id="excludeCount">0</span>
+                    </div>
+                    <div class="compare-selector">
+                        <label for="excludePermission">Add excluded permission:</label>
+                        <div class="compare-input-wrapper">
+                            <input type="text" id="excludePermission" class="search-input" placeholder="Type to search permissions..." autocomplete="off">
+                            <button type="button" class="add-permission-button" id="addExcludeButton">Add</button>
+                        </div>
+                        <div id="excludeSuggestions" class="suggestions-dropdown"></div>
+                    </div>
+                    <div id="excludeList" class="selected-permissions-list"></div>
+                </div>
+            </div>
+
+            <div class="match-summary" id="matchSummary">
+                <span id="matchCount">0</span> matching roles
+            </div>
+
+            <div class="role-table" id="matchTable">
+                <div class="role-table-header">
+                    <div class="role-name-header">Role Name</div>
+                    <div class="role-type-header">Role Type</div>
+                </div>
+                <div id="matchRows"></div>
+            </div>
+        </section>
+    </main>
+
+    {{template "footer" .}}
+
+    <script>
+        const STORAGE_KEY = 'gcpIamCatalogRoleSearch';
+        const MAX_SUGGESTIONS = 50;
+        let allPermissions = [];
+        let roleMetadata = {};
+        let permissionRoleCache = {};
+        let state = {
+            include: [],
+            exclude: []
+        };
+
+        async function loadCatalogData() {
+            const [permissionsResponse, metadataResponse] = await Promise.all([
+                fetch('permissions-list.json'),
+                fetch('roles-metadata.json')
+            ]);
+
+            if (!permissionsResponse.ok) {
+                throw new Error('Failed to load permissions list');
+            }
+            if (!metadataResponse.ok) {
+                throw new Error('Failed to load role metadata');
+            }
+
+            allPermissions = await permissionsResponse.json();
+            roleMetadata = await metadataResponse.json();
+        }
+
+        function loadSavedState() {
+            try {
+                const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+                state.include = Array.isArray(saved.include) ? saved.include : [];
+                state.exclude = Array.isArray(saved.exclude) ? saved.exclude : [];
+            } catch (err) {
+                state = { include: [], exclude: [] };
+            }
+        }
+
+        function saveState() {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+        }
+
+        function normalizePermission(value) {
+            const trimmed = value.trim();
+            return allPermissions.find(permission => permission.toLowerCase() === trimmed.toLowerCase()) || trimmed;
+        }
+
+        function sortPermissions(items) {
+            return items.sort((a, b) => a.permission.localeCompare(b.permission));
+        }
+
+        function activePermissions(side) {
+            return state[side].filter(item => item.active).map(item => item.permission);
+        }
+
+        function permissionDataPath(permission) {
+            return 'permissionsdata/' + permission.replace(/\//g, '-') + '.json';
+        }
+
+        async function rolesForPermission(permission) {
+            if (permissionRoleCache[permission]) {
+                return permissionRoleCache[permission];
+            }
+
+            const response = await fetch(permissionDataPath(permission));
+            if (!response.ok) {
+                throw new Error('Failed to load permission: ' + permission);
+            }
+            const data = await response.json();
+            permissionRoleCache[permission] = data.roles || [];
+            return permissionRoleCache[permission];
+        }
+
+        function findSuggestions(value, side) {
+            const filter = value.trim().toLowerCase();
+            if (filter.length < 2) {
+                return [];
+            }
+
+            const selected = new Set([
+                ...state.include.map(item => item.permission.toLowerCase()),
+                ...state.exclude.map(item => item.permission.toLowerCase())
+            ]);
+
+            return allPermissions
+                .filter(permission => !selected.has(permission.toLowerCase()) && permission.toLowerCase().includes(filter))
+                .sort((a, b) => {
+                    const aStarts = a.toLowerCase().startsWith(filter);
+                    const bStarts = b.toLowerCase().startsWith(filter);
+                    if (aStarts && !bStarts) return -1;
+                    if (!aStarts && bStarts) return 1;
+                    return a.localeCompare(b);
+                })
+                .slice(0, MAX_SUGGESTIONS);
+        }
+
+        function showSuggestions(side) {
+            const input = document.getElementById(side + 'Permission');
+            const container = document.getElementById(side + 'Suggestions');
+            container.innerHTML = '';
+
+            const matches = findSuggestions(input.value, side);
+            if (matches.length === 0) {
+                container.style.display = 'none';
+                return;
+            }
+
+            matches.forEach(permission => {
+                const item = document.createElement('div');
+                item.className = 'suggestion-item';
+                item.textContent = permission;
+                item.addEventListener('click', () => {
+                    input.value = permission;
+                    container.style.display = 'none';
+                    addPermission(side);
+                });
+                container.appendChild(item);
+            });
+            container.style.display = 'block';
+        }
+
+        function addPermission(side) {
+            const input = document.getElementById(side + 'Permission');
+            const permission = normalizePermission(input.value);
+            const knownPermission = allPermissions.includes(permission);
+
+            input.classList.toggle('input-error', !knownPermission);
+            if (!knownPermission) {
+                return;
+            }
+
+            const duplicate = state.include.concat(state.exclude).some(item => item.permission === permission);
+            if (!duplicate) {
+                state[side].push({ permission: permission, active: true });
+                sortPermissions(state[side]);
+                saveState();
+                renderSelectedPermissions();
+                updateMatches();
+            }
+
+            input.value = '';
+            input.classList.remove('input-error');
+            document.getElementById(side + 'Suggestions').style.display = 'none';
+        }
+
+        function removePermission(side, permission) {
+            state[side] = state[side].filter(item => item.permission !== permission);
+            saveState();
+            renderSelectedPermissions();
+            updateMatches();
+        }
+
+        function togglePermission(side, permission, active) {
+            const item = state[side].find(candidate => candidate.permission === permission);
+            if (item) {
+                item.active = active;
+                saveState();
+                renderSelectedPermissions();
+                updateMatches();
+            }
+        }
+
+        function renderSelectedPermissions() {
+            ['include', 'exclude'].forEach(side => {
+                const container = document.getElementById(side + 'List');
+                container.innerHTML = '';
+
+                if (state[side].length === 0) {
+                    const empty = document.createElement('div');
+                    empty.className = 'selected-permission-empty';
+                    empty.textContent = side === 'include' ? 'No required permissions added' : 'No excluded permissions added';
+                    container.appendChild(empty);
+                }
+
+                state[side].forEach(item => {
+                    const row = document.createElement('div');
+                    row.className = 'selected-permission' + (item.active ? '' : ' inactive');
+
+                    const label = document.createElement('label');
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.checked = item.active;
+                    checkbox.addEventListener('change', () => togglePermission(side, item.permission, checkbox.checked));
+                    label.appendChild(checkbox);
+
+                    const link = document.createElement('a');
+                    link.href = 'permissions/' + item.permission.split('/').map(encodeURIComponent).join('/') + '.html';
+                    link.textContent = item.permission;
+                    label.appendChild(link);
+                    row.appendChild(label);
+
+                    const removeButton = document.createElement('button');
+                    removeButton.type = 'button';
+                    removeButton.className = 'remove-permission-button';
+                    removeButton.textContent = 'Remove';
+                    removeButton.addEventListener('click', () => removePermission(side, item.permission));
+                    row.appendChild(removeButton);
+                    container.appendChild(row);
+                });
+            });
+
+            document.getElementById('includeCount').textContent = activePermissions('include').length;
+            document.getElementById('excludeCount').textContent = activePermissions('exclude').length;
+        }
+
+        function roleSort(a, b) {
+            return a.localeCompare(b);
+        }
+
+        function displayRoleName(role) {
+            return role + (roleMetadata[role] && roleMetadata[role].deprecated ? ' ⛔' : '');
+        }
+
+        function renderMatches(roles) {
+            const rows = document.getElementById('matchRows');
+            rows.innerHTML = '';
+            document.getElementById('matchCount').textContent = roles.length.toLocaleString();
+
+            if (roles.length === 0) {
+                const empty = document.createElement('div');
+                empty.className = 'search-empty-state';
+                empty.textContent = activePermissions('include').length || activePermissions('exclude').length
+                    ? 'No roles match the active filters.'
+                    : 'Add permissions to start finding roles.';
+                rows.appendChild(empty);
+                return;
+            }
+
+            roles.forEach(role => {
+                const row = document.createElement('div');
+                row.className = 'role-row';
+
+                const nameCell = document.createElement('div');
+                nameCell.className = 'role-name-cell';
+                const indicator = document.createElement('span');
+                indicator.className = 'role-indicator';
+                nameCell.appendChild(indicator);
+
+                const link = document.createElement('a');
+                link.href = 'roles/' + encodeURIComponent(role.replace('roles/', '')) + '.html';
+                link.className = 'role-name';
+                link.textContent = displayRoleName(role);
+                nameCell.appendChild(link);
+                row.appendChild(nameCell);
+
+                const typeCell = document.createElement('div');
+                typeCell.className = 'role-type-cell';
+                typeCell.textContent = roleMetadata[role] ? roleMetadata[role].type : '';
+                row.appendChild(typeCell);
+
+                rows.appendChild(row);
+            });
+        }
+
+        async function updateMatches() {
+            const includes = activePermissions('include');
+            const excludes = activePermissions('exclude');
+
+            if (includes.length === 0 && excludes.length === 0) {
+                renderMatches([]);
+                return;
+            }
+
+            try {
+                const includeRoleLists = await Promise.all(includes.map(rolesForPermission));
+                const excludeRoleLists = await Promise.all(excludes.map(rolesForPermission));
+                let candidates;
+
+                if (includeRoleLists.length > 0) {
+                    candidates = includeRoleLists
+                        .map(list => new Set(list))
+                        .reduce((intersection, current) => new Set([...intersection].filter(role => current.has(role))));
+                } else {
+                    candidates = new Set(Object.keys(roleMetadata));
+                }
+
+                const excludedRoles = new Set(excludeRoleLists.flat());
+                const matches = [...candidates].filter(role => !excludedRoles.has(role)).sort(roleSort);
+                renderMatches(matches);
+            } catch (err) {
+                console.error(err);
+                renderMatches([]);
+            }
+        }
+
+        function bindPermissionInput(side) {
+            const input = document.getElementById(side + 'Permission');
+            const addButton = document.getElementById('add' + side.charAt(0).toUpperCase() + side.slice(1) + 'Button');
+
+            input.addEventListener('input', () => {
+                input.classList.remove('input-error');
+                showSuggestions(side);
+            });
+            input.addEventListener('keydown', event => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    addPermission(side);
+                }
+            });
+            addButton.addEventListener('click', () => addPermission(side));
+        }
+
+        document.addEventListener('DOMContentLoaded', async () => {
+            try {
+                await loadCatalogData();
+                loadSavedState();
+                renderSelectedPermissions();
+                await updateMatches();
+                bindPermissionInput('include');
+                bindPermissionInput('exclude');
+
+                document.addEventListener('click', event => {
+                    if (!event.target.closest('.compare-selector')) {
+                        document.getElementById('includeSuggestions').style.display = 'none';
+                        document.getElementById('excludeSuggestions').style.display = 'none';
+                    }
+                });
+            } catch (err) {
+                console.error(err);
+                document.getElementById('matchRows').innerHTML = '<div class="search-empty-state">Unable to load search data.</div>';
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

This PR adds an interactive client-side role search page that lets users find GCP IAM roles by specifying permissions a role **must include** and permissions it **must exclude**.

## Changes

### New Features
- **Search page** () — A full-page interactive tool for filtering roles by required and excluded permissions
- **Permission suggestions** — Auto-complete dropdown as you type permission names
- **Persistent state** — Filter selections are saved to  and restored on page load
- **Client-side matching** — Intersection of include-role-lists minus exclude-role-lists, all in the browser
- **Role type classification** — Roles are now classified by type (e.g., predefined, custom, system)

### Backend Changes
- **Role metadata** — Extended  struct with  and  fields
- **Search page generation** — Added search page generation during the HTML catalog build process
- **CSS updates** — Added styles for the search page layout, permission panels, match results, and empty states

### Template Updates
- Minor nav bar updates across index, roles, permissions, role, and permission pages

## Screenshots / Demo

The search page provides:
1. Two panels: **Must Include** and **Must Exclude** permissions
2. Live match count and ranked role results
3. Deprecated roles are visually indicated with a ⛔ icon
4. Links to individual role and permission detail pages