### PR TITLE
fix: address zizmor security findings in semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -14,16 +14,18 @@ jobs:
   semgrep:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep
+      image: semgrep/semgrep@sha256:65dcd4408adda7c183a6b4550cb1e9b19f7f627a6fbb7e0559bd466bedc44d7b # v1.172.0
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Scan
         run: semgrep scan --config auto --sarif --output semgrep.sarif
 
       - name: Upload findings to GitHub
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.0
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: semgrep.sarif
           category: semgrep


### PR DESCRIPTION
Fix 3 zizmor security issues in semgrep workflow:
- Pin container image to digest (`semgrep/semgrep@sha256:...` v1.172.0)
- Add `persist-credentials: false` to actions/checkout
- Fix upload-sarif version comment to match pinned hash (v4.37.6)